### PR TITLE
add multiple targets again (Pi4, Pi3, TX1, and RK3399)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This is a simple Debian repository for the [box86](https://github.com/ptitSeb/box86) project. New versions are compiled every 24 hours if a new commit on box86's repository has been made, you can find all the debs here: https://github.com/ryanfortner/box86-debs/commits/master
 
+These debs have been compiled using various target CPUs and systems. You can see all the available pkgs below.
+
+## Package List
+Package Name | Notes | Install Command |
+------------ | ------------- | ------------- |
+| box86 | box86 built for RPI4ARM64 target. | `sudo apt install box86` |
+| box86-rpi3arm64 | box86 built for RPI3ARM64 target. | `sudo apt install box86-rpi3arm64` |
+| box86-generic-arm | box86 built for generic ARM systems. | `sudo apt install box86-generic-arm` |
+| box86-tegrax1 | box86 built for Tegra X1 systems. | `sudo apt install box86-tegrax1` |
+| box86-rk3399 | box86 built for rk3399 cpu target. | `sudo apt install box86-rk3399` |
+
+Want me to build for more platforms? Open an issue. 
+
 ### Repository installation
 Involves adding .list file and gpg key for added security.
 ```

--- a/create-deb.sh
+++ b/create-deb.sh
@@ -19,7 +19,7 @@ cd $DIRECTORY
 
 # install dependencies
 apt-get update
-apt-get install wget git build-essential python3 make gettext pinentry-tty sudo devscripts dpkg-dev -y || error "Failed to install dependencies"
+apt-get install wget git build-essential gcc-8 python3 make gettext pinentry-tty sudo devscripts dpkg-dev -y || error "Failed to install dependencies"
 git clone https://github.com/giuliomoro/checkinstall || error "Failed to clone checkinstall repo"
 cd checkinstall
 sudo make install || error "Failed to run make install for Checkinstall!"
@@ -41,37 +41,52 @@ fi
 echo "box86 is not the latest version, compiling now."
 echo $commit > $DIRECTORY/commit.txt
 echo "Wrote commit to commit.txt file for use during the next compilation."
-mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRPI4=1 || error "Failed to run cmake."
-make -j4 || error "Failed to run make."
 
-function get-box86-version() {
-	if [[ $1 == "ver" ]]; then
-		export BOX86VER="$(./box86 -v | cut -c21-25)"
-	elif [[ $1 == "commit" ]]; then
-		export BOX86COMMIT="$commit"
-	fi
-}
+targets=(ARM64 RPI4ARM64 RPI3ARM64 TEGRAX1 RK3399)
 
-get-box86-version ver  || error "Failed to get box86 version!"
-get-box86-version commit || error "Failed to get box86 commit!"
-DEBVER="$(echo "$BOX86VER+$(date +"%F" | sed 's/-//g').$BOX86COMMIT")" || error "Failed to set debver variable."
+for target in ${targets[@]}; do
 
-mkdir doc-pak || error "Failed to create doc-pak dir."
-cp ../docs/README.md ./doc-pak || warning "Failed to add README to docs"
-cp ../docs/CHANGELOG.md ./doc-pak || error "Failed to add CHANGELOG to docs"
-cp ../docs/USAGE.md ./doc-pak || error "Failed to add USAGE to docs"
-cp ../docs/X86WINE.md ./doc-pak || error "Failed to add X86WINE to docs"
-cp ../LICENSE ./doc-pak || error "Failed to add LICENSE to docs"
-echo "Box86 lets you run x86 Linux programs (such as games) on non-x86 Linux systems, like ARM (host system needs to be 32bit little-endian)">description-pak || error "Failed to create description-pak."
-echo "#!/bin/bash
-echo 'Restarting systemd-binfmt...'
-systemctl restart systemd-binfmt || true" > postinstall-pak || error "Failed to create postinstall-pak!"
+  cd $DIRECTORY/box86
+  sudo rm -rf build && mkdir build && cd build || error "Could not move to build directory"
+  cmake .. -D$target=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=gcc-8 || error "Failed to run cmake."
+  make -j4 || error "Failed to run make."
 
-sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="armhf" --provides="box86" --conflicts="qemu-user-static" --pkgname="box86" --install="no" make install || error "Checkinstall failed to create a deb package."
+  function get-box86-version() {
+    if [[ $1 == "ver" ]]; then
+      export BOX86VER="$(./box86 -v | cut -c21-25)"
+    elif [[ $1 == "commit" ]]; then
+      export BOX86COMMIT="$commit"
+    fi
+  }
 
-cd $DIRECTORY
-mv box86/build/*.deb ./debian/ || error "Failed to move deb to debian folder."
+  get-box86-version ver  || error "Failed to get box86 version!"
+  get-box86-version commit || error "Failed to get box86 commit!"
+  DEBVER="$(echo "$BOX86VER+$(date +"%F" | sed 's/-//g').$BOX86COMMIT")" || error "Failed to set debver variable."
+
+  mkdir doc-pak || error "Failed to create doc-pak dir."
+  cp ../docs/README.md ./doc-pak || warning "Failed to add README to docs"
+  cp ../docs/CHANGELOG.md ./doc-pak || error "Failed to add CHANGELOG to docs"
+  cp ../docs/USAGE.md ./doc-pak || error "Failed to add USAGE to docs"
+  cp ../docs/X86WINE.md ./doc-pak || error "Failed to add X86WINE to docs"
+  cp ../LICENSE ./doc-pak || error "Failed to add LICENSE to docs"
+  echo "Box86 lets you run x86 Linux programs (such as games) on non-x86 Linux systems, like ARM (host system needs to be 32bit little-endian)">description-pak || error "Failed to create description-pak."
+  echo "#!/bin/bash
+  echo 'Restarting systemd-binfmt...'
+  systemctl restart systemd-binfmt || true" > postinstall-pak || error "Failed to create postinstall-pak!"
+
+  # use the pi4 target as the default box86 package
+  if [[ $target == "RPI4ARM64" ]]; then
+    sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="armhf" --provides="box86" --conflicts="qemu-user-static" --pkgname="box86" --install="no" make install || error "Checkinstall failed to create a deb package."
+  elif [[ $target == "ARM64" ]]; then
+    sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="armhf" --provides="box86" --conflicts="qemu-user-static" --pkgname="box86-generic-arm" --install="no" make install || error "Checkinstall failed to create a deb package."
+  else
+    sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="armhf" --provides="box86" --conflicts="qemu-user-static" --pkgname="box86-$target" --install="no" make install || error "Checkinstall failed to create a deb package."
+  fi
+
+  cd $DIRECTORY
+  mv box86/build/*.deb ./debian/ || error "Failed to move deb to debian folder."
+
+done
 
 rm -rf $DIRECTORY/box86
 


### PR DESCRIPTION
needed for https://github.com/Botspot/pi-apps/pull/2275

removed GPG key so I could test and triggered here (force pushed back after starting the actions) https://github.com/theofficialgman/box86-debs/actions/runs/4368569161/jobs/7641318904

it isn't done yet but as you can see, it is compiling the first target without any issues

btw, why are we using armhf/arm64 containers on these repos? box86/box64 can be cross compiled very easily as seen on the official repos in the CI and it would 5-10X faster to compile that way