### PR TITLE
switch box86 rpi4 package to box86-rpi4arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These debs have been compiled using various target CPUs and systems. You can see
 
 Package Name | Notes | Install Command |
 ------------ | ------------- | ------------- |
-| box86 | box86 built for RPI4ARM64 target. | `sudo apt install box86` |
+| box86-rpi4arm64 | box86 built for RPI4ARM64 target. | `sudo apt install box86-rpi4arm64` |
 | box86-rpi3arm64 | box86 built for RPI3ARM64 target. | `sudo apt install box86-rpi3arm64` |
 | box86-generic-arm | box86 built for generic ARM systems. | `sudo apt install box86-generic-arm` |
 | box86-tegrax1 | box86 built for Tegra X1 systems. | `sudo apt install box86-tegrax1` |
@@ -23,7 +23,7 @@ Involves adding .list file and gpg key for added security.
 ```
 sudo wget https://ryanfortner.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
 wget -O- https://ryanfortner.github.io/box86-debs/KEY.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/box86-debs-archive-keyring.gpg
-sudo apt update && sudo apt install box86 -y
+sudo apt update && sudo apt install box86-rpi4arm64 -y
 ```
 
 If you don't want to add this apt repository to your system, you can download and install the latest armhf deb from [here](https://github.com/ryanfortner/box86-debs/tree/master/debian).
@@ -34,7 +34,7 @@ It's possible to run box86 on an arm64 machine, but you need to add the armhf ar
 sudo dpkg --add-architecture armhf
 sudo apt-get update
 # proceed to add the repo using instructions above
-sudo apt-get install box86:armhf
+sudo apt-get install box86-rpi4arm64:armhf
 ```
 
 ### Note for box64

--- a/create-deb.sh
+++ b/create-deb.sh
@@ -78,10 +78,7 @@ for target in ${targets[@]}; do
   echo 'Restarting systemd-binfmt...'
   systemctl restart systemd-binfmt || true" > postinstall-pak || error "Failed to create postinstall-pak!"
 
-  # use the pi4 target as the default box86 package
-  if [[ $target == "RPI4ARM64" ]]; then
-    sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="armhf" --provides="box86" --conflicts="qemu-user-static" --pkgname="box86" --install="no" make install || error "Checkinstall failed to create a deb package."
-  elif [[ $target == "ARM64" ]]; then
+  if [[ $target == "ARM64" ]]; then
     sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="armhf" --provides="box86" --conflicts="qemu-user-static" --pkgname="box86-generic-arm" --install="no" make install || error "Checkinstall failed to create a deb package."
   else
     sudo checkinstall -y -D --pkgversion="$DEBVER" --arch="armhf" --provides="box86" --conflicts="qemu-user-static" --pkgname="box86-$target" --install="no" make install || error "Checkinstall failed to create a deb package."


### PR DESCRIPTION
all packages provide box86 so any other package can still depend on box86. previously the user could not guarantee the installation of the rpi4 box86 package, installing box86 would result in a random selection of any of the packages that provide it. now the user or script can select the box86-rpi4arm64 target explicitly